### PR TITLE
Fix rpm 4.15+ compatibility

### DIFF
--- a/key_checker.py
+++ b/key_checker.py
@@ -58,7 +58,7 @@ def buildKeyList(file=None):
     '''Build a dict of public keys in the rpm database'''
     keys = ts.dbMatch(rpm.RPMTAG_NAME, 'gpg-pubkey')
     for hdr in keys:
-        pubkeys[hdr[rpm.RPMTAG_VERSION].decode()] = hdr[rpm.RPMTAG_SUMMARY].decode()[4:-1]
+        pubkeys[hdr[rpm.RPMTAG_VERSION]] = hdr[rpm.RPMTAG_PACKAGER]
     if file:
         lines = open(file, 'r').read().splitlines()
         for line in lines:
@@ -73,18 +73,18 @@ def getPkgNevra(hdr):
     '''Return a formatted string of the nevra of a header object'''
     if hdr[rpm.RPMTAG_EPOCH]:
         return '{0}-{1}:{2}-{3}.{4}'.format(
-            hdr[rpm.RPMTAG_NAME].decode(),
+            hdr[rpm.RPMTAG_NAME],
             hdr[rpm.RPMTAG_EPOCH],
-            hdr[rpm.RPMTAG_VERSION].decode(),
-            hdr[rpm.RPMTAG_RELEASE].decode(),
-            hdr[rpm.RPMTAG_ARCH].decode()
+            hdr[rpm.RPMTAG_VERSION],
+            hdr[rpm.RPMTAG_RELEASE],
+            hdr[rpm.RPMTAG_ARCH]
         )
     else:
         return '{0}-{1}-{2}.{3}'.format(
-            hdr[rpm.RPMTAG_NAME].decode(),
-            hdr[rpm.RPMTAG_VERSION].decode(),
-            hdr[rpm.RPMTAG_RELEASE].decode(),
-            hdr[rpm.RPMTAG_ARCH].decode()
+            hdr[rpm.RPMTAG_NAME],
+            hdr[rpm.RPMTAG_VERSION],
+            hdr[rpm.RPMTAG_RELEASE],
+            hdr[rpm.RPMTAG_ARCH]
         )
 
 def getSig(hdr):
@@ -137,7 +137,7 @@ def getPkg(name=None):
     exists = False
     for hdr in mi:
         exists = True
-        if hdr[rpm.RPMTAG_NAME].decode() == 'gpg-pubkey':
+        if hdr[rpm.RPMTAG_NAME] == 'gpg-pubkey':
             continue
         nevra, key = getSig(hdr)
         try:


### PR DESCRIPTION
Before rpm 4.15, rpm's python3 bindings would return string data as bytes.  This script worked around that behavior by proactively decoding them, which was a noop on python2, retaining compatibility.  In rpm 4.15 this behavior was corrected so that string data is returned as utf8 strings, which had a side effect of breaking our workaround on python3.  The change was also backported to RHEL as rpm-4.14.2-25.el8, available since RHEL 8.1.  The last Fedora release with the old behavior was Fedora 30, meaning all OS's with the bytes behavior are EOL.  We can just use the strings as is, which works on all current Fedora and RHEL releases.

https://github.com/jds2001/keychecker/commit/da993741f78d873f6619384a2c857ec6710aa2fb
https://github.com/rpm-software-management/rpm/commit/84920f898315d09a57a3f1067433eaeb7de5e830
https://access.redhat.com/errata/RHBA-2019:3584